### PR TITLE
bump gitopscli to v3.0.0

### DIFF
--- a/tekton-chatopshandler/chatops-pipeline.yaml
+++ b/tekton-chatopshandler/chatops-pipeline.yaml
@@ -38,14 +38,14 @@ spec:
       - name: prorg
       - name: apiurl
       - name: gitopscli-version
-        default: v2.1.0
+        default: v3.0.0
   stepTemplate:
     envFrom:
       - secretRef:
           name: github-token
   steps:
     - name: get-branch-name-step
-      image: baloiseincubator/gitopscli:$(inputs.params.gitopscli-version)
+      image: baloise/gitopscli:$(inputs.params.gitopscli-version)
       env:
         - name: PRID
           value: "$(inputs.params.prid)"
@@ -76,7 +76,7 @@ spec:
         f = open("/workspace/branchfile.txt","w+")
         f.write(branchName)
     - name: perform-chat-ops-step
-      image: baloiseincubator/gitopscli:$(inputs.params.gitopscli-version)
+      image: baloise/gitopscli:$(inputs.params.gitopscli-version)
       script: |
         branchName=$(cat /workspace/branchfile.txt)
         echo "$branchName"
@@ -87,7 +87,6 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --organisation $(inputs.params.prorg) \
           --repository-name $(inputs.params.reponame) \
           --text='You can <br>use the command `/ping`!' \
@@ -97,12 +96,10 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --git-user incubator-tekton \
           --git-email joachim.prinzbach+github-ttt-travis-bot@gmail.com \
           --organisation $(inputs.params.prorg) \
           --repository-name $(inputs.params.reponame) \
-          --branch "$branchName" \
           --pr-id $(inputs.params.prid) \
           --create-pr \
           --auto-merge
@@ -111,7 +108,6 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --git-user incubator-tekton \
           --git-email joachim.prinzbach+github-ttt-travis-bot@gmail.com \
           --organisation $(inputs.params.prorg) \
@@ -124,7 +120,6 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --organisation $(inputs.params.prorg) \
           --repository-name $(inputs.params.reponame) \
           --text='Need help? Find the docs, examples and a F.A.Q.: [Baloise Incubator: GitOps Cli](https://baloise-incubator.github.io/gitopscli/)' \

--- a/tekton-chatopshandler/initial-greeting-pipeline.yaml
+++ b/tekton-chatopshandler/initial-greeting-pipeline.yaml
@@ -38,14 +38,14 @@ spec:
       - name: action
       - name: branchname
       - name: gitopscli-version
-        default: v2.1.0
+        default: v3.0.0
   stepTemplate:
     envFrom:
       - secretRef:
           name: github-token
   steps:
     - name: run-command
-      image: baloiseincubator/gitopscli:$(inputs.params.gitopscli-version)
+      image: baloise/gitopscli:$(inputs.params.gitopscli-version)
       script: |
         branchName=$(cat /workspace/branchfile.txt)
         echo "$branchName"
@@ -54,7 +54,6 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --organisation $(inputs.params.prorg) \
           --repository-name $(inputs.params.reponame) \
           --text='Welcome to Baloise ChatOps based GitOps Bot.<br><br>If you want to enable preview environments for this PullRequest, comment with `/preview`.<br>If you want to disable the preview environment for this PR, comment with `/undeploy`.<br>If you need help or want to see the docs, comment with `/help`.<br><br>At the moment, preview environments do not get redeployed automatically. Simply rewrite `/preview` or contribute the feature.' \
@@ -64,7 +63,6 @@ spec:
           --username incubator-tekton \
           --password $token \
           --git-provider github \
-          --git-provider-url https://github.com/ \
           --git-user incubator-tekton \
           --git-email joachim.prinzbach+github-ttt-travis-bot@gmail.com \
           --organisation $(inputs.params.prorg) \

--- a/tekton-chatopshandler/syncapps-pipeline.yaml
+++ b/tekton-chatopshandler/syncapps-pipeline.yaml
@@ -26,20 +26,19 @@ spec:
       - name: reponame
       - name: rootorg
       - name: gitopscli-version
-        default: v2.1.0
+        default: v3.0.0
   stepTemplate:
     envFrom:
       - secretRef:
           name: github-token
   steps:
     - name: run-command
-      image: baloiseincubator/gitopscli:$(inputs.params.gitopscli-version)
+      image: baloise/gitopscli:$(inputs.params.gitopscli-version)
       script: |
         gitopscli sync-apps \
         --username incubator-tekton \
         --password $token \
         --git-provider github \
-        --git-provider-url https://github.com/ \
         --git-user incubator-tekton \
         --git-email joachim.prinzbach+github-ttt-travis-bot@gmail.com \
         --organisation $(inputs.params.rootorg) \


### PR DESCRIPTION
- pull from official baloise dockerhub org
- `--git-provider-url` is not needed for github
- `create-preview` doesn't need `--branch` anymore